### PR TITLE
update: check subscription event #1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
 config.json
+userdata

--- a/README_ja.md
+++ b/README_ja.md
@@ -29,9 +29,9 @@
     "DISCORD_TOKEN": "<Discord BOTのTOKEN>",
     "STRIPE_API_KEY": "<sk_...から始まるStripeのAPI KEY>",
     "SERVER_PORT": <サーバーのポート>,
-    "DISCORD_GUILD_ID": <対象サーバーのID>,
+    "DISCORD_GUILD_ID": "<対象サーバーのID>",
     "ROLES": {
-        "<prod_...から始まるStripe商品のID>": <付与したいロールのID>
+        "<prod_...から始まるStripe商品のID>": "<付与したいロールのID>"
     }
 }
 ```

--- a/REASON.md
+++ b/REASON.md
@@ -1,0 +1,110 @@
+# REASON
+Webhookが送信されると下のようなJSONを返送します。
+
+```json
+{
+    "status": "success",
+    "message": "Role added",
+    "code": 500
+}
+```
+
+`status`部と`message`部と`code`部の3部分に分かれています。
+
+- `status`  
+  処理が成功したか失敗したかを表します。  
+  `success`か`error`のどちらかが入ります。
+
+- `message`  
+  処理の結果を表します。
+
+- `code`  
+  処理の結果を表すステータスコードを表します。  
+  これは、決してHTTPステータスコードとは関係ありません。
+
+また、全てのステータス及びメッセージはコードを確認すれば分かります。
+
+また、成功か失敗かだけを確認したい場合は、`code`の1桁目を確認してください。  
+`0`なら成功、`1`以上なら失敗です。
+
+# コード一覧
+## 1xx
+
+これは、`checkout.session`の処理中に送信されるものです。
+
+### 100
+
+status: `success`
+message: `Product is not supported`
+
+これは、このサービスがサポートしていない商品が購入された場合に返されます。  
+この場合、ロールは操作されません。
+
+## 2xx
+
+これは、`subscription`の処理中に送信されるものです。
+
+### 200
+
+status: `success`
+message: `Product is not supported`
+
+これは、このサービスがサポートしていない商品が購入された場合に返されます。  
+この場合、ロールは操作されません。
+
+### 201
+
+status: `error`
+message: `Customer not found`
+
+これは、サブスクリプションが更新したユーザーの情報が見つからなかった場合に送信されます。
+
+## 3xx
+
+これは、ロール操作で`SKIP`をするときに送信されるものです。
+
+### 300
+
+status: `error`
+message: `Action skipped`
+
+これは、ロールが何も操作されなかったことを示します。  
+主に、料金が支払われていないが、まだSubscriptionオブジェクトがincompleteのままの状態の場合に送信されます。
+
+## 4xx
+
+これは、ロール操作前のDiscordユーザー取得時に送信されるものです。
+
+### 401
+
+status: `error`
+message: `Member not found`
+
+これは、Discordユーザーが見つからなかった場合に送信されます。
+
+## 5xx
+
+これは、ロール操作時に送信されるものです。
+
+### 500
+
+status: `success`
+message: `OK`
+
+これは、ロール操作が成功した場合に送信されます。
+
+## 9xx
+### 900
+
+status: `success`
+message: `Event not supported`
+
+これは、このサービスがサポートしていないイベントが送信された場合に返されます。
+
+### 901
+
+status: `error`
+message: `Method not allowed`
+
+これは、このサービスがサポートしていないHTTPメソッドが送信された場合に返されます。  
+このサービスのWebhookエンドポイントはPOSTのみをサポートしています。

--- a/clientmodel.py
+++ b/clientmodel.py
@@ -1,34 +1,69 @@
+import asyncio
 import aiohttp
 
 class Client:
-    def __init__(self, token: str, guild_id: int) -> None:
-        self.token = token
-        self.guild_id = guild_id
+    def __init__(self, token: str, guild_id: int | str, api_version: int | None = None) -> None:
+        """Initialize the client"""
+        self.token = token # Discord Bot Token
+        self.guild_id = str(guild_id) # Discord Guild ID
+        self._content_type = "application/json" # HTTP Request Content-Type
+        self._authorization = f"Bot {self.token}" # HTTP Request Authorization
+        self._base_url = "https://discord.com/api" # Discord API Base URL
+        self.api_version: int | None = api_version # Discord API Version
+        self._api_url = f"{self._base_url}/v{self.api_version}" if self.api_version else self._base_url # Discord API URL
+        self._session = aiohttp.ClientSession() # aiohttp ClientSession
 
-    async def add_role(self, member_id: int, role_id: int, reason: str = "Subscriptions were settled by Stripe. (dinosaur-stripeconnect)"):
+    async def _add_role(self, member_id: str | int, role_id: str | int, reason: str = "Subscription with Stripe is now active. (dinosaur-stripeconnect)"):
         headers = {
-            "Authorization": f"Bot {self.token}",
-            "Content-Type": "application/json",
+            "Authorization": self._authorization,
+            "Content-Type": self._content_type,
             "X-Audit-Log-Reason": reason
         }
-        async with aiohttp.ClientSession() as sess:
-            async with sess.put(f"https://discord.com/api/guilds/{self.guild_id}/members/{member_id}/roles/{role_id}", headers=headers) as resp:
+        async with self._session as sess:
+            async with sess.put(f"{self._api_url}/guilds/{self.guild_id}/members/{member_id}/roles/{role_id}", headers=headers) as resp:
                 if resp.status == 204:
                     return True
                 else:
                     return False
 
+    async def add_roles(self, member_id: str | int, role_ids: str | int | list[str] | list[int], reason: str = "Subscription with Stripe is now active. (dinosaur-stripeconnect)"):
+        if isinstance(role_ids, str) or isinstance(role_ids, int):
+            role_ids = [role_ids]
+        for role_id in role_ids:
+            await self._add_role(member_id, role_id, reason=reason)
+            await asyncio.sleep(1)
+
+    async def _del_role(self, member_id: str | int, role_id: str | int, reason: str = "Subscription with Stripe has been deactivated. (dinosaur-stripeconnect)"):
+        headers = {
+            "Authorization": self._authorization,
+            "Content-Type": self._content_type,
+            "X-Audit-Log-Reason": reason
+        }
+        async with self._session as sess:
+            async with sess.delete(f"{self._api_url}/guilds/{self.guild_id}/members/{member_id}/roles/{role_id}", headers=headers) as resp:
+                if resp.status == 204:
+                    return True
+                else:
+                    return False
+
+    async def del_roles(self, member_id: str | int, role_ids: str | int | list[str] | list[int], reason: str = "Subscription with Stripe has been deactivated. (dinosaur-stripeconnect)"):
+        if isinstance(role_ids, str) or isinstance(role_ids, int):
+            role_ids = [role_ids]
+        for role_id in role_ids:
+            await self._del_role(member_id, role_id, reason=reason)
+            await asyncio.sleep(1)
+
     async def _fetch_members(self, member_name: str) -> list | bool:
         headers = {
-            "Authorization": f"Bot {self.token}",
-            "Content-Type": "application/json"
+            "Authorization": self._authorization,
+            "Content-Type": self._content_type
         }
         query = {
             "query": member_name,
             "limit": 1000
         }
-        async with aiohttp.ClientSession() as sess:
-            async with sess.get(f"https://discord.com/api/guilds/{self.guild_id}/members/search", headers=headers, params=query) as resp:
+        async with self._session as sess:
+            async with sess.get(f"{self._api_url}/guilds/{self.guild_id}/members/search", headers=headers, params=query) as resp:
                 if resp.status == 200:
                     return await resp.json()
                 else:

--- a/config.example.json
+++ b/config.example.json
@@ -2,8 +2,8 @@
     "DISCORD_TOKEN": "aabbccddee....",
     "STRIPE_API_KEY": "sk_test_aabbcc...",
     "SERVER_PORT": 5500,
-    "DISCORD_GUILD_ID": 123456789012345678,
+    "DISCORD_GUILD_ID": "123456789012345678",
     "ROLES": {
-        "prod_12345...": 123456789012345678
+        "prod_12345...": "123456789012345678"
     }
 }

--- a/configmodel.py
+++ b/configmodel.py
@@ -3,8 +3,9 @@ class Config:
         self.DISCORD_TOKEN = DISCORD_TOKEN
         if STRIPE_API_KEY[:3] != "sk_":
             raise ValueError("Invalid Stripe API Key (Stripe API Key must start with 'sk_')")
+        self.LIVE = False
         if STRIPE_API_KEY[:8] == "sk_live_":
-            print("########## WARNING ##########\nStripe API Key is a live key ('sk_live_').")
+            self.LIVE = True
         self.STRIPE_API_KEY = STRIPE_API_KEY
         self.DISCORD_GUILD_ID = DISCORD_GUILD_ID
         self.SERVER_PORT = SERVER_PORT

--- a/main.py
+++ b/main.py
@@ -1,5 +1,10 @@
+import asyncio
+import aiofiles
 import sanic
 import json
+import enum
+
+import sys
 
 from async_stripe import stripe
 
@@ -8,39 +13,205 @@ import configmodel
 
 CONFIG = configmodel.Config(**json.load(open("config.json", "r")))
 
-app = sanic.Sanic(f"dinosaur-stripeconnect")
 stripe.api_key = CONFIG.STRIPE_API_KEY
 client = clientmodel.Client(CONFIG.DISCORD_TOKEN, CONFIG.DISCORD_GUILD_ID)
 
-checkout_history = []
+async def write_userdata(data) -> None:
+    async with aiofiles.open("userdata", "w") as f:
+        await f.write(json.dumps(data))
 
-@app.post("/webhook")
-async def webhook(request):
+async def read_userdata() -> dict[str, str]:
+    try:
+        with open("userdata", "r") as f:
+            return json.loads(f.read())
+    except FileNotFoundError:
+        with open("userdata", "w") as f:
+            f.write("{}")
+        return {}
+
+event_history = []
+
+class ActionType(enum.Enum):
+    ADD = 1
+    REMOVE = 2
+    ADDITIONAL_REMOVE = 3
+    SKIP = 4
+
+app = sanic.Sanic(f"dinosaur-stripeconnect-{'LIVE' if CONFIG.LIVE else 'TEST'}")
+
+@app.route("/webhook", methods=["GET", "DELETE", "HEAD", "OPTIONS", "PATCH", "PUT", "POST"])
+async def webhook(request: sanic.Request):
+    if request.method != "POST":
+        return sanic.response.json({"status": "error", "message": "Method not allowed", "code": 901})
+
+    if request.json["id"] in event_history:
+        return sanic.response.json({"status": "success", "message": "Event already processed (Duplicate or Resend)", "code": 100})
+    else:
+        event_history.append(request.json["id"])
+
     data = request.json["data"]["object"]
-    if data["id"] in checkout_history:
-        return # Skip if already processed
+    userdata = await read_userdata()
+
+    actions = []
+
+    # print(data)
+    # if data["id"] in checkout_history:
+    #     return # Skip if already processed
+    # else:
+    #     checkout_history.append(data["id"])
+
+    if request.json["type"] == "customer.subscription.deleted":
+        print("Subscription Deleted Event")
+        if data["customer"] not in userdata:
+            return sanic.response.json({"status": "error", "message": "Customer not found", "code": 201})
+        user = userdata[data["customer"]]
+
+        username, discriminator = "#".join(user.split("#")[:-1]), user.split("#")[-1]
+        member = await client.fetch_member(username, discriminator)
+        if not member:
+            return sanic.response.json({"status": "error", "message": "Member not found", "code": 401})
+        member_id = member["user"]["id"] # 1234567890123
+
+        for item in data["items"]["data"]:
+            product = item["plan"]["product"] # prod_...
+
+            if product not in CONFIG.ROLES:
+                continue
+
+            role_id = CONFIG.ROLES[product] # 1234567890123
+            actions.append({
+                "action": ActionType.REMOVE,
+                "role_id": role_id,
+            })
+
+    elif request.json["type"] == "checkout.session.completed":
+        print("Checkout Session Event")
+        # Checkout Session Event
+        user = data["custom_fields"][0]["text"]["value"] # Discord#0000
+        customer = data["customer"] # cus_...
+        userdata[customer] = user
+        asyncio.ensure_future(write_userdata(userdata))
+        subscription = await stripe.Subscription.retrieve(data["subscription"]) # Subscription Object
+
+        product = subscription["items"]["data"][0]["plan"]["product"] # prod_...
+
+        username, discriminator = "#".join(user.split("#")[:-1]), user.split("#")[-1]
+        member = await client.fetch_member(username, discriminator)
+        if not member:
+            return sanic.response.json({"status": "error", "message": "Member not found", "code": 401})
+        member_id = member["user"]["id"] # 1234567890123
+
+        if product not in CONFIG.ROLES:
+            return sanic.response.json({"status": "success", "message": "Product is not supported", "code": 100})
+        role_id = CONFIG.ROLES[product] # 1234567890123
+
+        status = subscription["status"]
+
+        match status:
+            case "trialing":
+                action = ActionType.ADD
+            case "active":
+                action = ActionType.ADD
+            case "incomplete":
+                action = ActionType.SKIP
+            case "incomplete_expired":
+                action = ActionType.REMOVE
+            case "past_due":
+                action = ActionType.REMOVE
+            case "canceled":
+                action = ActionType.REMOVE
+            case "unpaid":
+                action = ActionType.REMOVE
+
+        actions.append({
+            "action": action,
+            "role_id": role_id,
+        })
+
+    elif request.json["type"] == "customer.subscription.updated":
+        print("Subscription Update Event")
+        # Subscription Update Event
+
+        if data["customer"] not in userdata:
+            return sanic.response.json({"status": "error", "message": "Customer not found", "code": 201})
+        user = userdata[data["customer"]]
+
+        username, discriminator = "#".join(user.split("#")[:-1]), user.split("#")[-1]
+        member = await client.fetch_member(username, discriminator)
+        if not member:
+            return sanic.response.json({"status": "error", "message": "Member not found", "code": 401})
+        member_id = member["user"]["id"] # 1234567890123
+
+        if "previous_attributes" in request.json["data"]:
+            if "items" in request.json["data"]["previous_attributes"]:
+                print("Previous attributes found")
+                for item in request.json["data"]["previous_attributes"]["items"]["data"]:
+                    # previous_product = request.json["data"]["previous_attributes"]["items"]["data"][0]["plan"]["product"] # prod_...
+                    product = item["plan"]["product"] # prod_...
+                    if product in CONFIG.ROLES:
+                        role_id = CONFIG.ROLES[product] # 1234567890123
+                        await client.del_roles(member_id, role_id)
+
+        for item in data["items"]["data"]:
+            product = item["plan"]["product"]
+
+            if product not in CONFIG.ROLES:
+                continue
+
+            role_id = CONFIG.ROLES[product] # 1234567890123
+            status = data["status"]
+            match status:
+                case "trialing":
+                    action = ActionType.ADD
+                case "active":
+                    action = ActionType.ADD
+                case "incomplete":
+                    action = ActionType.SKIP
+                case "incomplete_expired":
+                    action = ActionType.REMOVE
+                case "past_due":
+                    action = ActionType.REMOVE
+                case "canceled":
+                    action = ActionType.REMOVE
+                case "unpaid":
+                    action = ActionType.REMOVE
+            actions.append({
+                "action": action,
+                "role_id": role_id,
+            })
+
     else:
-        checkout_history.append(data["id"])
-    if data["mode"] != "subscription":
-        return sanic.response.json({"status": "success", "message": "Not a subscription", "code": 0})
-    user = data["custom_fields"][0]["text"]["value"] # ちゃんと入れてくれてればユーザー名になっているはず。
-    subscription = await stripe.Subscription.retrieve(data["subscription"])
-    product = subscription["items"]["data"][0]["price"]["product"] # Product ID
-    username, discriminator = "#".join(user.split("#")[:-1]), user.split("#")[-1]
-    member = await client.fetch_member(username, discriminator)
-    if not member:
-        return sanic.response.json({"status": "error", "message": "Member not found", "code": 1})
-    member_id = member["user"]["id"]
-    if product not in CONFIG.ROLES:
-        return sanic.response.json({"status": "success", "message": "Product not supported", "code": 0})
-    role_id = CONFIG.ROLES[product]
-    result = await client.add_role(member_id, role_id)
-    if result:
-        return sanic.response.json({"status": "success", "message": "OK", "code": 0})
-    else:
-        return sanic.response.json({"status": "error", "message": "Failed to add role", "code": 2})
+        return sanic.response.json({"status": "success", "message": "Event not supported", "code": 900})
+
+    await client.add_roles(member_id, [action["role_id"] for action in actions if action["action"] == ActionType.ADD])
+    await client.del_roles(member_id, [action["role_id"] for action in actions if action["action"] == ActionType.REMOVE])
+
+    return sanic.response.json({"status": "success", "message": "OK", "code": 500})
+
+
+
+    #subscription = await stripe.Subscription.retrieve(data["subscription"])
+    #product = subscription["items"]["data"][0]["price"]["product"] # Product ID
+    #username, discriminator = "#".join(user.split("#")[:-1]), user.split("#")[-1]
+    #member = await client.fetch_member(username, discriminator)
+    #if not member:
+    #    return sanic.response.json({"status": "error", "message": "Member not found", "code": 1})
+    #member_id = member["user"]["id"]
+    #if product not in CONFIG.ROLES:
+    #    return sanic.response.json({"status": "success", "message": "Product not supported", "code": 0})
+    #role_id = CONFIG.ROLES[product]
+    #result = await client.add_role(member_id, role_id)
+    #if result:
+    #    return sanic.response.json({"status": "success", "message": "OK", "code": 0})
+    #else:
+    #    return sanic.response.json({"status": "error", "message": "Failed to add role", "code": 2})
 
 if __name__ == "__main__":
     print("dinosaur-stripeconnect")
+    if CONFIG.LIVE:
+        print("""\
+########## ATTENTION! ##########
+You are running this in LIVE mode.
+################################""")
     print(f"The webhook url is 'http://localhost:{CONFIG.SERVER_PORT}/webhook' (localrun)")
     app.run("0.0.0.0", CONFIG.SERVER_PORT)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 async-stripe
 sanic
 aiohttp
+aiofiles


### PR DESCRIPTION
from #1 

Checkout Session(`checkout.session.completed`)だけの監視から、Subscription Event(`customer.subscription.updated`/`customer.subscription.deleted`)の監視も追加した。
これによって、今まで「サブスクリプションの購入時」にのみロールが付与されていたのが、下記の通り変更される。

- ロール付与
  - サブスクリプションの購入時（チェックアウト）
  - サブスクリプションで指定のプランへの乗り換え
- ロール削除
  - サブスクリプションでのキャンセル
  - サブスクリプションでの別プランへの乗り換え
  - サブスクリプションの支払い状況が`unpaid`などに変更された